### PR TITLE
bare implementation of a triplestore router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk:
+  - oraclejdk7
+before_install:  
+ - "echo $JAVA_OPTS"
+ - "export JAVA_OPTS=-Xmx512m"
+notifications:
+  irc: "irc.freenode.org#duraspace-ff"
+  email:
+      - fedora-tech@googlegroups.com
+

--- a/audit-triplestore/ReadMe.txt
+++ b/audit-triplestore/ReadMe.txt
@@ -1,0 +1,20 @@
+Camel Router Project for Blueprint (OSGi)
+=========================================
+
+To build this project use
+
+    mvn install
+
+To run the project you can execute the following Maven goal
+
+    mvn camel:run
+
+To deploy the project in OSGi. For example using Apache ServiceMix
+or Apache Karaf. You can run the following command from its shell:
+
+    osgi:install -s mvn:org.fcrepo.camel/audit-triplestore/4.1.2-SNAPSHOT
+
+For more help see the Apache Camel documentation
+
+    http://camel.apache.org/
+

--- a/audit-triplestore/pom.xml
+++ b/audit-triplestore/pom.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>9</version>
+  </parent>
+
+  <groupId>org.fcrepo.camel</groupId>
+  <artifactId>audit-triplestore</artifactId>
+  <packaging>bundle</packaging>
+  <version>4.1.2-SNAPSHOT</version>
+
+  <name>Fedora Audit System with a Triplestore backend</name>
+  <description>Camel-based audit system built with a triplestore backend</description>
+  <url>http://fcrepo.org</url>
+
+  <organization>
+    <name>DuraSpace, Inc.</name>
+    <url>http://www.duraspace.org/</url>
+  </organization>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.copyrightYear>2015</project.copyrightYear>
+
+    <!-- Use ${project_name} instead of ${project.artifactId} to avoid incorrect
+      replacements of "fcrepo4" in child modules (for scm, site-distribution, etc -->
+    <project_name>fcrepo-audit-triplestore</project_name>
+
+    <!-- https://github.com/github/maven-plugins/blob/master/README.md -->
+    <github.global.server>github</github.global.server>
+
+    <!-- dependencies -->
+    <activemq.version>5.10.0</activemq.version>
+    <camel.version>2.15.1</camel.version>
+    <commons.lang3.version>3.3.2</commons.lang3.version>
+    <slf4j.version>1.7.10</slf4j.version>
+    <!-- plugins -->
+    <bundle.plugin.version>2.3.7</bundle.plugin.version>
+    <checkstyle.plugin.version>2.14</checkstyle.plugin.version>
+    <compiler.plugin.version>3.2</compiler.plugin.version>
+    <license.plugin.version>2.9</license.plugin.version>
+  </properties>
+
+  <prerequisites>
+    <maven>3.0.0</maven>
+  </prerequisites>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <comments>Copyright (c) 2015 DuraSpace</comments>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/fcrepo4/${project_name}.git</connection>
+    <developerConnection>scm:git:git@github.com:fcrepo4/${project_name}.git</developerConnection>
+    <url>https://github.com/fcrepo4/fcrepo-camel</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>${camel.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-blueprint</artifactId>
+      <version>${camel.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http4</artifactId>
+      <version>${camel.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-camel</artifactId>
+      <version>${activemq.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>fcrepo-camel</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang3.version}</version>
+    </dependency>
+
+    <!-- logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <!-- Testing & Camel Plugin -->
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-test-blueprint</artifactId>
+      <version>${camel.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+
+      <!-- to generate the MANIFEST-FILE of the bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>${bundle.plugin.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+           <id>bundle-manifest</id>
+           <phase>process-classes</phase>
+           <goals>
+               <goal>manifest</goal>
+           </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>audit-triplestore</Bundle-SymbolicName>
+            <Private-Package>org.fcrepo.camel.audit.triplestore.*</Private-Package>
+            <Import-Package>*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+
+       <!-- to run the example using mvn camel:run -->
+      <plugin>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-maven-plugin</artifactId>
+        <version>${camel.version}</version>
+        <configuration>
+          <useBlueprint>true</useBlueprint>
+        </configuration>
+      </plugin>
+
+      <!-- verify that source files contain the correct license headers
+        $ mvn license:check to check files
+        $ mvn license:format to update files -->
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>${license.plugin.version}</version>
+        <configuration>
+          <header>fcrepo-license/LICENSE_HEADER.txt</header>
+          <includes>
+            <include>**/src/main/java/**</include>
+            <include>**/src/test/java/**</include>
+            <include>**/examples/fcrepo-camel-osgi/src/main/java/**</include>
+            <include>**/examples/fcrepo-camel-scala/src/main/scala/**</include>
+          </includes>
+          <excludes>
+            <exclude>target/**</exclude>
+            <exclude>**/src/test/resources/**</exclude>
+            <exclude>**/src/main/resources/**</exclude>
+            <exclude>**/*.properties</exclude>
+          </excludes>
+          <properties>
+            <name>${project.artifactId}</name>
+            <year>${project.copyrightYear}</year>
+            <holder>${project.organization.name}</holder>
+          </properties>
+          <encoding>UTF-8</encoding>
+          <strictCheck>true</strictCheck>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-build-tools</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${checkstyle.plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-build-tools</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
+          <consoleOutput>true</consoleOutput>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <failsOnError>true</failsOnError>
+          <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
+          <configLocation>fcrepo-checkstyle/checkstyle.xml</configLocation>
+          <suppressionsLocation>fcrepo-checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
+        </configuration>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- compile with java7 -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${compiler.plugin.version}</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/audit-triplestore/pom.xml
+++ b/audit-triplestore/pom.xml
@@ -4,24 +4,16 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
+    <groupId>org.fcrepo.camel</groupId>
+    <artifactId>fcrepo-camel-toolbox</artifactId>
+    <version>4.1.2-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.fcrepo.camel</groupId>
   <artifactId>audit-triplestore</artifactId>
   <packaging>bundle</packaging>
-  <version>4.1.2-SNAPSHOT</version>
 
   <name>Fedora Audit System with a Triplestore backend</name>
   <description>Camel-based audit system built with a triplestore backend</description>
-  <url>http://fcrepo.org</url>
-
-  <organization>
-    <name>DuraSpace, Inc.</name>
-    <url>http://www.duraspace.org/</url>
-  </organization>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -32,249 +24,58 @@
       replacements of "fcrepo4" in child modules (for scm, site-distribution, etc -->
     <project_name>fcrepo-audit-triplestore</project_name>
 
-    <!-- https://github.com/github/maven-plugins/blob/master/README.md -->
-    <github.global.server>github</github.global.server>
-
-    <!-- dependencies -->
-    <activemq.version>5.10.0</activemq.version>
-    <camel.version>2.15.1</camel.version>
-    <commons.lang3.version>3.3.2</commons.lang3.version>
-    <slf4j.version>1.7.10</slf4j.version>
     <!-- plugins -->
     <bundle.plugin.version>2.3.7</bundle.plugin.version>
-    <checkstyle.plugin.version>2.14</checkstyle.plugin.version>
-    <compiler.plugin.version>3.2</compiler.plugin.version>
-    <license.plugin.version>2.9</license.plugin.version>
   </properties>
 
-  <prerequisites>
-    <maven>3.0.0</maven>
-  </prerequisites>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-      <comments>Copyright (c) 2015 DuraSpace</comments>
-    </license>
-  </licenses>
-
-  <scm>
-    <connection>scm:git:git://github.com/fcrepo4/${project_name}.git</connection>
-    <developerConnection>scm:git:git@github.com:fcrepo4/${project_name}.git</developerConnection>
-    <url>https://github.com/fcrepo4/fcrepo-camel</url>
-    <tag>HEAD</tag>
-  </scm>
-
-  <repositories>
-    <repository>
-      <id>snapshots-repo</id>
-      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
-
   <dependencies>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-core</artifactId>
-      <version>${camel.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-blueprint</artifactId>
-      <version>${camel.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-http4</artifactId>
-      <version>${camel.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-camel</artifactId>
-      <version>${activemq.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.fcrepo.camel</groupId>
-      <artifactId>fcrepo-camel</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons.lang3.version}</version>
-    </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-core</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-blueprint</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-http4</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>activemq-camel</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.fcrepo.camel</groupId>
+        <artifactId>fcrepo-camel</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+      </dependency>
 
-    <!-- logging -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-    <!-- Testing & Camel Plugin -->
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-test-blueprint</artifactId>
-      <version>${camel.version}</version>
-    </dependency>
+      <!-- logging -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+      </dependency>
+      <!-- Testing & Camel Plugin -->
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-test-blueprint</artifactId>
+        <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>
     <defaultGoal>install</defaultGoal>
-
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.5.1</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
-
-      <!-- to generate the MANIFEST-FILE of the bundle -->
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${bundle.plugin.version}</version>
-        <extensions>true</extensions>
-        <executions>
-          <execution>
-           <id>bundle-manifest</id>
-           <phase>process-classes</phase>
-           <goals>
-               <goal>manifest</goal>
-           </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>audit-triplestore</Bundle-SymbolicName>
-            <Private-Package>org.fcrepo.camel.audit.triplestore.*</Private-Package>
-            <Import-Package>*</Import-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-
-       <!-- to run the example using mvn camel:run -->
-      <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-        <version>${camel.version}</version>
-        <configuration>
-          <useBlueprint>true</useBlueprint>
-        </configuration>
-      </plugin>
-
-      <!-- verify that source files contain the correct license headers
-        $ mvn license:check to check files
-        $ mvn license:format to update files -->
-      <plugin>
-        <groupId>com.mycila</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>${license.plugin.version}</version>
-        <configuration>
-          <header>fcrepo-license/LICENSE_HEADER.txt</header>
-          <includes>
-            <include>**/src/main/java/**</include>
-            <include>**/src/test/java/**</include>
-            <include>**/examples/fcrepo-camel-osgi/src/main/java/**</include>
-            <include>**/examples/fcrepo-camel-scala/src/main/scala/**</include>
-          </includes>
-          <excludes>
-            <exclude>target/**</exclude>
-            <exclude>**/src/test/resources/**</exclude>
-            <exclude>**/src/main/resources/**</exclude>
-            <exclude>**/*.properties</exclude>
-          </excludes>
-          <properties>
-            <name>${project.artifactId}</name>
-            <year>${project.copyrightYear}</year>
-            <holder>${project.organization.name}</holder>
-          </properties>
-          <encoding>UTF-8</encoding>
-          <strictCheck>true</strictCheck>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.fcrepo</groupId>
-            <artifactId>fcrepo-build-tools</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${checkstyle.plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.fcrepo</groupId>
-            <artifactId>fcrepo-build-tools</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <consoleOutput>true</consoleOutput>
-          <logViolationsToConsole>true</logViolationsToConsole>
-          <failsOnError>true</failsOnError>
-          <failOnViolation>true</failOnViolation>
-          <violationSeverity>warning</violationSeverity>
-          <configLocation>fcrepo-checkstyle/checkstyle.xml</configLocation>
-          <suppressionsLocation>fcrepo-checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
-        </configuration>
-        <executions>
-          <execution>
-            <id>checkstyle</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- compile with java7 -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler.plugin.version}</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-
     </plugins>
+
   </build>
 
 </project>

--- a/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
+++ b/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.audit.triplestore;
+
+import org.apache.camel.Processor;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.fcrepo.camel.JmsHeaders;
+
+/**
+ * A processor that converts an audit message into a sparql-update
+ * statement for an external triplestore.
+ *
+ * @author Aaron Coburn
+ */
+
+public class AuditSparqlProcessor implements Processor {
+
+    /**
+     * Define how a message should be processed.
+     *
+     * @param exchange the current camel message exchange
+     */
+    public void process(final Exchange exchange) throws Exception {
+        final Message in = exchange.getIn();
+
+        // A UUID for this event -- this can be generated here or come from an existing header
+        final String eventId = in.getHeader("CamelFcrepoAuditEventId", String.class);
+        // this is a list that will need to be split on commas
+        final String eventType = in.getHeader(JmsHeaders.EVENT_TYPE, String.class);
+        final String baseUrl = in.getHeader(JmsHeaders.BASE_URL, String.class);
+        final String identifier = in.getHeader(JmsHeaders.IDENTIFIER, String.class);
+        final Long timestamp = Long.parseLong(in.getHeader(JmsHeaders.TIMESTAMP, String.class), 10);
+        final String user = in.getHeader(JmsHeaders.USER, String.class);
+        final String userAgent = in.getHeader(JmsHeaders.USER_AGENT, String.class);
+        // this is a list that will need to be split on commas
+        final String properties = in.getHeader(JmsHeaders.PROPERTIES, String.class);
+        // Once fcrepo-camel has these headers, use const vals
+        final String fixity = in.getHeader("org.fcrepo.jms.fixity", String.class);
+        final String digest = in.getHeader("org.fcrepo.jms.contentDigest", String.class);
+        final Integer size = in.getHeader("org.fcrepo.jms.contentSize", Integer.class);
+
+        final StringBuilder query = new StringBuilder("update=");
+
+        // add triples here (Jena or Clerezza, whichever is easiest)
+
+        in.setBody(query.toString());
+        in.setHeader(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        in.setHeader(Exchange.HTTP_METHOD, "POST");
+    }
+}

--- a/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/EventRouter.java
+++ b/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/EventRouter.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.audit.triplestore;
+
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * A content router for handling JMS events.
+ *
+ * @author Aaron Coburn
+ */
+public class EventRouter extends RouteBuilder {
+
+    /**
+     * Configure the message route workflow.
+     */
+    public void configure() throws Exception {
+
+        /**
+         * A generic error handler (specific to this RouteBuilder)
+         */
+        onException(Exception.class)
+            .maximumRedeliveries(10)
+            .log("Event Routing Error: ${routeId}");
+
+        /**
+         * Process a message.
+         */
+        from("activemq:{{jms.fcrepoEndpoint}}")
+            .routeId("AuditEventRouter")
+            .process(new AuditSparqlProcessor())
+            .to("http4:{{triplestore.baseUrl}}/statements");
+    }
+}

--- a/audit-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/audit-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+       xsi:schemaLocation="
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+   <!-- OSGI blueprint property placeholder -->
+   <cm:property-placeholder persistent-id="org.fcrepo.camel.audit" update-strategy="reload">
+     <cm:default-properties>
+       <cm:property name="jms.brokerUrl" value="tcp://localhost:61616"/>
+       <cm:property name="jms.fcrepoEndpoint" value="topic:fedora"/>
+       <cm:property name="triplestore.baseUrl" value="localhost:3030/ds/test"/>
+     </cm:default-properties>
+   </cm:property-placeholder>
+
+
+  <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
+    <property name="brokerURL" value="${jms.brokerUrl}"/>
+  </bean>
+
+  <camelContext xmlns="http://camel.apache.org/schema/blueprint">
+
+    <package>org.fcrepo.camel.audit.triplestore</package>
+  </camelContext>
+
+</blueprint>

--- a/audit-triplestore/src/main/resources/log4j.properties
+++ b/audit-triplestore/src/main/resources/log4j.properties
@@ -1,0 +1,18 @@
+#
+# The logging properties used for testing
+#
+log4j.rootLogger=INFO, out
+
+#log4j.logger.org.apache.camel=DEBUG
+
+# CONSOLE appender not used by default
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=[%30.30t] %-30.30c{1} %-5p %m%n
+#log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+
+# File appender
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d %-5p %c{1} - %m %n
+log4j.appender.file.file=target/camel-test.log

--- a/audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/RouteTest.java
+++ b/audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/RouteTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.audit.triplestore;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.fcrepo.camel.JmsHeaders;
+import org.fcrepo.camel.RdfNamespaces;
+
+import org.junit.Test;
+
+/**
+ * Test the route workflow.
+ *
+ * @author Aaron Coburn
+ */
+public class RouteTest extends CamelBlueprintTestSupport {
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    @Override
+    protected String getBlueprintDescriptor() {
+        return "/OSGI-INF/blueprint/blueprint.xml";
+    }
+
+    @Test
+    public void testEventProcessor() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(JmsHeaders.BASE_URL, "http://localhost/rest");
+        headers.put(JmsHeaders.IDENTIFIER, "/foo");
+        headers.put(JmsHeaders.TIMESTAMP, "1428360320168");
+        headers.put(JmsHeaders.EVENT_TYPE, RdfNamespaces.REPOSITORY + "NODE_ADDED");
+        headers.put(JmsHeaders.USER, "bypassAdmin");
+        headers.put(JmsHeaders.USER_AGENT, "curl/7.37.1");
+        template.sendBodyAndHeaders(null, headers);
+
+        // assert expectations
+        assertMockEndpointsSatisfied();
+    }
+
+
+    @Test
+    public void testFixityProcessor() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(JmsHeaders.BASE_URL, "http://localhost/rest");
+        headers.put(JmsHeaders.IDENTIFIER, "/foo");
+        headers.put(JmsHeaders.TIMESTAMP, "1428360320168");
+        headers.put(JmsHeaders.EVENT_TYPE, RdfNamespaces.REPOSITORY + "FIXITY");
+        headers.put("org.fcrepo.jms.fixity", "foo");
+        headers.put("org.fcrepo.jms.contentDigest", "blahblahblah");
+        headers.put("org.fcrepo.jms.contentSize", "100");
+        headers.put("org.fcrepo.jms.user", "bypassAdmin");
+        headers.put("org.fcrepo.jms.userAgent", "curl/7.37.1");
+        template.sendBodyAndHeaders(null, headers);
+
+        // assert expectations
+        assertMockEndpointsSatisfied();
+    }
+
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws IOException {
+                from("direct:start")
+                    .process(new AuditSparqlProcessor())
+                    .to("mock:result");
+            }
+        };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>9</version>
+  </parent>
+
+  <groupId>org.fcrepo.camel</groupId>
+  <artifactId>fcrepo-camel-toolbox</artifactId>
+  <packaging>pom</packaging>
+  <version>4.1.2-SNAPSHOT</version>
+
+  <name>Fedora4 Camel workflows</name>
+  <description>A collection of camel-based event-driven workflows</description>
+  <url>http://fcrepo.org</url>
+
+  <organization>
+    <name>DuraSpace, Inc.</name>
+    <url>http://www.duraspace.org/</url>
+  </organization>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.copyrightYear>2015</project.copyrightYear>
+
+    <!-- Use ${project_name} instead of ${project.artifactId} to avoid incorrect
+      replacements of "fcrepo4" in child modules (for scm, site-distribution, etc -->
+    <project_name>fcrepo-camel-toolbox</project_name>
+
+    <!-- https://github.com/github/maven-plugins/blob/master/README.md -->
+    <github.global.server>github</github.global.server>
+
+    <!-- dependencies -->
+    <activemq.version>5.10.0</activemq.version>
+    <camel.version>2.15.1</camel.version>
+    <commons.lang3.version>3.3.2</commons.lang3.version>
+    <slf4j.version>1.7.10</slf4j.version>
+    <!-- osgi -->
+    <fcrepo.camel.osgi.import>*</fcrepo.camel.osgi.import>
+    <!-- plugins -->
+    <bundle.plugin.version>2.3.7</bundle.plugin.version>
+    <checkstyle.plugin.version>2.14</checkstyle.plugin.version>
+    <compiler.plugin.version>3.2</compiler.plugin.version>
+    <license.plugin.version>2.9</license.plugin.version>
+  </properties>
+
+  <modules>
+    <module>audit-triplestore</module>
+  </modules>
+
+  <prerequisites>
+    <maven>3.0.0</maven>
+  </prerequisites>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <comments>Copyright (c) 2015 DuraSpace</comments>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/fcrepo4-labs/${project_name}.git</connection>
+    <developerConnection>scm:git:git@github.com:fcrepo4-labs/${project_name}.git</developerConnection>
+    <url>https://github.com/fcrepo4-labs/fcrepo-camel-toolbox</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-core</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-blueprint</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-http4</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>activemq-camel</artifactId>
+        <version>${activemq.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.fcrepo.camel</groupId>
+        <artifactId>fcrepo-camel</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons.lang3.version}</version>
+      </dependency>
+
+      <!-- logging -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <!-- Testing & Camel Plugin -->
+      <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-test-blueprint</artifactId>
+        <version>${camel.version}</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.5.1</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.6</version>
+          <configuration>
+            <encoding>UTF-8</encoding>
+          </configuration>
+        </plugin>
+
+         <!-- to run the example using mvn camel:run -->
+        <plugin>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-maven-plugin</artifactId>
+          <version>${camel.version}</version>
+          <configuration>
+            <useBlueprint>true</useBlueprint>
+          </configuration>
+        </plugin>
+
+        <!-- verify that source files contain the correct license headers
+          $ mvn license:check to check files
+          $ mvn license:format to update files -->
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license.plugin.version}</version>
+          <configuration>
+            <header>fcrepo-license/LICENSE_HEADER.txt</header>
+            <includes>
+              <include>**/src/main/java/**</include>
+              <include>**/src/test/java/**</include>
+              <include>**/examples/fcrepo-camel-osgi/src/main/java/**</include>
+              <include>**/examples/fcrepo-camel-scala/src/main/scala/**</include>
+            </includes>
+            <excludes>
+              <exclude>target/**</exclude>
+              <exclude>**/src/test/resources/**</exclude>
+              <exclude>**/src/main/resources/**</exclude>
+              <exclude>**/*.properties</exclude>
+            </excludes>
+            <properties>
+              <name>${project.artifactId}</name>
+              <year>${project.copyrightYear}</year>
+              <holder>${project.organization.name}</holder>
+            </properties>
+            <encoding>UTF-8</encoding>
+            <strictCheck>true</strictCheck>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.fcrepo</groupId>
+              <artifactId>fcrepo-build-tools</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${checkstyle.plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.fcrepo</groupId>
+              <artifactId>fcrepo-build-tools</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+            <consoleOutput>true</consoleOutput>
+            <logViolationsToConsole>true</logViolationsToConsole>
+            <failsOnError>true</failsOnError>
+            <failOnViolation>true</failOnViolation>
+            <violationSeverity>warning</violationSeverity>
+            <configLocation>fcrepo-checkstyle/checkstyle.xml</configLocation>
+            <suppressionsLocation>fcrepo-checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
+          </configuration>
+          <executions>
+            <execution>
+              <id>checkstyle</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <!-- compile with java7 -->
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${compiler.plugin.version}</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <!-- to generate the MANIFEST-FILE of the bundle -->
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>${bundle.plugin.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+           <id>bundle-manifest</id>
+           <phase>process-classes</phase>
+           <goals>
+               <goal>manifest</goal>
+           </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-Name>${project.artifactId}</Bundle-Name>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Import-Package>${fcrepo.camel.osgi.import}</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
This partially resolves https://jira.duraspace.org/browse/FCREPO-1421

A basic testing framework is in place along with the standard fcrepo maven configuration.

What is needed is an actual implementation of the AuditSparqlProcessor class and a corresponding expansion of the RouteTest class.

@escowles should be able to take things from here.