### PR TITLE
code cleanup; decouple route processing

### DIFF
--- a/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditHeaders.java
+++ b/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditHeaders.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.audit.triplestore;
+
+/**
+ * @author acoburn
+ */
+public final class AuditHeaders {
+
+    public static final String EVENT_BASE_URI = "CamelAuditEventBaseUri";
+
+    private AuditHeaders() {
+        // prevent instantiation
+    }
+}

--- a/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditNamespaces.java
+++ b/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditNamespaces.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.audit.triplestore;
+
+/**
+ * @author acoburn
+ */
+public final class AuditNamespaces {
+
+    public static final String AUDIT = "http://fedora.info/definitions/v4/audit#";
+    public static final String EVENT_TYPE = "http://id.loc.gov/vocabulary/preservation/eventType/";
+    public static final String PREMIS = "http://www.loc.gov/premis/rdf/v1#";
+    public static final String PROV = "http://www.w3.org/ns/prov#";
+    public static final String XSD = "http://www.w3.org/2001/XMLSchema#";
+
+    private AuditNamespaces() {
+        // prevent instantiation
+    }
+}

--- a/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
+++ b/audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
@@ -17,6 +17,11 @@ package org.fcrepo.camel.audit.triplestore;
 
 import static org.fcrepo.camel.RdfNamespaces.RDF;
 import static org.fcrepo.camel.RdfNamespaces.REPOSITORY;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.AUDIT;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.EVENT_TYPE;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.PREMIS;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.PROV;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.XSD;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -61,7 +66,7 @@ public class AuditSparqlProcessor implements Processor {
      */
     public void process(final Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
-        final String eventURIBase = (String) exchange.getProperty("event.baseUri");
+        final String eventURIBase = in.getHeader(AuditHeaders.EVENT_BASE_URI, String.class);
         final String UUIDString = UUID.randomUUID().toString();
         final UriRef eventURI = new UriRef(eventURIBase + "/" + UUIDString);
         final Set<Triple> triples = triplesForMessage(in, eventURI);
@@ -82,12 +87,6 @@ public class AuditSparqlProcessor implements Processor {
     }
 
     // namespaces and properties
-    public static final String AUDIT = "http://fedora.info/definitions/v4/audit#";
-    public static final String PREMIS = "http://www.loc.gov/premis/rdf/v1#";
-    public static final String EVENT_TYPE = "http://id.loc.gov/vocabulary/preservation/eventType/";
-    public static final String PROV = "http://www.w3.org/ns/prov#";
-    public static final String XSD = "http://www.w3.org/2001/XMLSchema#";
-
     private static final UriRef INTERNAL_EVENT = new UriRef(AUDIT + "InternalEvent");
     private static final UriRef PREMIS_EVENT = new UriRef(PREMIS + "Event");
     private static final UriRef PROV_EVENT = new UriRef(PROV + "InstantaneousEvent");

--- a/audit-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/audit-triplestore/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,11 +10,12 @@
    <!-- OSGI blueprint property placeholder -->
    <cm:property-placeholder persistent-id="org.fcrepo.camel.audit" update-strategy="reload">
      <cm:default-properties>
+       <cm:property name="error.maxRedeliveries" value="10"/>
        <cm:property name="jms.brokerUrl" value="tcp://localhost:61616"/>
        <cm:property name="jms.fcrepoEndpoint" value="topic:fedora"/>
-       <cm:property name="triplestore.baseUrl" value="localhost:3030/test/update?"/>
+       <cm:property name="triplestore.baseUrl" value="localhost:3030/test/update"/>
        <!-- Base URI to be used in contructing the URI for the JMS event -->
-       <cm:property name="event.baseUri" value="http://example.com"/>
+       <cm:property name="event.baseUri" value="http://example.com/event"/>
      </cm:default-properties>
    </cm:property-placeholder>
 
@@ -24,7 +25,6 @@
   </bean>
 
   <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-
     <package>org.fcrepo.camel.audit.triplestore</package>
   </camelContext>
 

--- a/audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/ProcessorTest.java
+++ b/audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/ProcessorTest.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2015 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.camel.audit.triplestore;
+
+import static org.fcrepo.camel.RdfNamespaces.REPOSITORY;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.AUDIT;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.EVENT_TYPE;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.PREMIS;
+import static org.fcrepo.camel.audit.triplestore.AuditNamespaces.XSD;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.fcrepo.camel.JmsHeaders;
+import org.apache.camel.test.junit4.CamelTestSupport;
+
+import org.junit.Test;
+
+/**
+ * Test the route workflow.
+ *
+ * @author escowles
+ * @author Aaron Coburn
+ * @since 2015-04-10
+ */
+public class ProcessorTest extends CamelTestSupport {
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint resultEndpoint;
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    private static final String baseURL = "http://localhost/rest";
+    private static final String eventBaseURI = "http://example.com/event";
+    private static final String nodeID = "/foo";
+    private static final String fileID = "/file1";
+    private static final long timestamp = 1428360320168L;
+    private static final String eventDate = "2015-04-06T22:45:20Z";
+    private static final String userID = "bypassAdmin";
+    private static final String userAgent = "curl/7.37.1";
+
+    @Test
+    public void testNodeAdded() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final String eventTypes = REPOSITORY + "NODE_ADDED," + REPOSITORY + "PROPERTY_ADDED";
+        final String eventProps = REPOSITORY + "lastModified," + REPOSITORY + "primaryType," +
+                REPOSITORY + "lastModifiedBy," + REPOSITORY + "created," + REPOSITORY + "mixinTypes," +
+                REPOSITORY + "createdBy," + REPOSITORY + "uuid";
+        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, eventProps));
+
+        assertMockEndpointsSatisfied();
+        final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
+        assertTrue("Event type not found!",
+            body.contains("<" + PREMIS + "hasEventType> <" + EVENT_TYPE + "cre>"));
+        assertTrue("Object link not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
+        assertTrue("Event date not found!",
+            body.contains("<" + PREMIS + "hasEventDateTime> \"" + eventDate + "\"^^<" + XSD + "dateTime>"));
+        assertTrue("Event user not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedAgent> \"" + userID + "\"^^<" + XSD + "string>"));
+        assertTrue("Event agent not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedAgent> \"" + userAgent + "\"^^<" + XSD + "string>"));
+    }
+
+    @Test
+    public void testNodeRemoved() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final String eventTypes = REPOSITORY + "NODE_REMOVED";
+        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, null));
+
+        assertMockEndpointsSatisfied();
+        final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
+        assertTrue("Event type not found!",
+            body.contains("<" + PREMIS + "hasEventType> <" + EVENT_TYPE + "del>"));
+        assertTrue("Object link not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
+    }
+
+    @Test
+    public void testPropertiesChanged() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final String eventTypes = REPOSITORY + "PROPERTY_CHANGED," + REPOSITORY + "PROPERTY_ADDED";
+        final String eventProps = REPOSITORY + "lastModified,http://purl.org/dc/elements/1.1/title";
+        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, eventProps));
+
+        assertMockEndpointsSatisfied();
+        final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
+        assertTrue("Event type not found!",
+            body.contains("<" + PREMIS + "hasEventType> <" + AUDIT + "metadataModification>"));
+        assertTrue("Object link not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
+    }
+
+    @Test
+    public void testFileAdded() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final String eventTypes = REPOSITORY + "NODE_ADDED," + REPOSITORY + "PROPERTY_ADDED";
+        final String eventProps = REPOSITORY + "lastModified," + REPOSITORY + "primaryType," +
+                REPOSITORY + "lastModifiedBy," + REPOSITORY + "created," + REPOSITORY + "mixinTypes," +
+                REPOSITORY + "createdBy," + REPOSITORY + "uuid" + REPOSITORY + "hasContent," +
+                PREMIS + "hasSize," + PREMIS + "hasOriginalName," + REPOSITORY + "digest";
+        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps));
+
+        assertMockEndpointsSatisfied();
+        final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
+        assertTrue("Event type not found!",
+            body.contains("<" + PREMIS + "hasEventType> <" + EVENT_TYPE + "ing>"));
+        assertTrue("Object link not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
+    }
+
+    @Test
+    public void testFileChanged() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final String eventTypes = REPOSITORY + "PROPERTY_CHANGED";
+        final String eventProps = REPOSITORY + "lastModified," + REPOSITORY + "hasContent," +
+                PREMIS + "hasSize," + PREMIS + "hasOriginalName," + REPOSITORY + "digest";
+        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps));
+
+        assertMockEndpointsSatisfied();
+        final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
+        assertTrue("Event type not found!",
+            body.contains("<" + PREMIS + "hasEventType> <" + AUDIT + "contentModification>"));
+        assertTrue("Object link not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
+    }
+
+    @Test
+    public void testFileRemoved() throws Exception {
+
+        resultEndpoint.expectedMessageCount(1);
+        resultEndpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+
+        final String eventTypes = REPOSITORY + "NODE_REMOVED";
+        final String eventProps = REPOSITORY + "hasContent";
+        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps));
+
+        assertMockEndpointsSatisfied();
+        final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
+        assertTrue("Event type not found!",
+            body.contains("<" + PREMIS + "hasEventType> <" + AUDIT + "contentRemoval>"));
+        assertTrue("Object link not found!",
+            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
+    }
+
+    private static Map<String,Object> createEvent(final String identifier, final String eventTypes,
+            final String eventProperties) {
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(JmsHeaders.BASE_URL, baseURL);
+        headers.put(JmsHeaders.IDENTIFIER, identifier);
+        headers.put(JmsHeaders.TIMESTAMP, timestamp);
+        headers.put(JmsHeaders.USER, userID);
+        headers.put(JmsHeaders.USER_AGENT, userAgent);
+        headers.put(JmsHeaders.EVENT_TYPE, eventTypes);
+        headers.put(JmsHeaders.PROPERTIES, eventProperties);
+        return headers;
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws IOException {
+                from("direct:start")
+                    .setHeader(AuditHeaders.EVENT_BASE_URI, constant(eventBaseURI))
+                    .process(new AuditSparqlProcessor())
+                    .to("mock:result");
+            }
+        };
+    }
+}

--- a/audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/integration/AuditSparqlIT.java
+++ b/audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/integration/AuditSparqlIT.java
@@ -35,6 +35,7 @@ import org.apache.camel.test.junit4.CamelTestSupport;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.fuseki.EmbeddedFusekiServer;
 import org.fcrepo.camel.JmsHeaders;
+import org.fcrepo.camel.audit.triplestore.AuditHeaders;
 import org.fcrepo.camel.audit.triplestore.AuditSparqlProcessor;
 import org.junit.After;
 import org.junit.Before;
@@ -260,6 +261,7 @@ public class AuditSparqlIT extends CamelTestSupport {
                 final String fuseki_url = "localhost:" + Integer.toString(FUSEKI_PORT);
 
                 from("direct:start")
+                    .setHeader(AuditHeaders.EVENT_BASE_URI, constant("http://example.com/event"))
                     .process(new AuditSparqlProcessor())
                     .to("http4:" + fuseki_url + "/test/update")
                     .to("mock:sparql.update");


### PR DESCRIPTION
This addresses: https://jira.duraspace.org/browse/FCREPO-1459

In addition, it cleans up the code significantly by adding a dedicated AuditHeader class for headers such as the one for the `event.baseUri` property, using a more standard Camel format. It also puts the RDF namespaces into a shared location for easier re-use.

The `EventRouter` class has been pulled apart into two simple routes, and the testing has been bifurcated into tests that verify the Processor class `ProcessorTest` and tests that check the actual Routes `RouteTest`. The `RouteTests` make significant use of the `AdviceWith` features so that we can bypass the need for an actual JMS broker in the unit tests. Doing so makes the tests run much faster as all the processor tests don't keep trying to connect to a local JMS broker.