### PR TITLE
added maven configuration for feature.xml generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ indexes objects into an external triplestore.
 To build these projects use this command
 
     MAVEN_OPTS="-Xmx1024m" mvn clean install
+
+## OSGi deployment (Karaf 3.x)
+
+These applications are distributed as OSGi features, meaning they can be installed
+directly from the karaf console. First, add the `fcrepo-camel-toolbox` repository:
+
+    $> feature:repo-add mvn:org.fcrepo.camel/fcrepo-camel-toolbox/LATEST/xml/features
+
+Then, you can add any combination of the following applications:
+
+    $> feature:install fcrepo-indexing-solr
+    $> feature:install fcrepo-indexing-triplestore
+    $> feature:install fcrepo-audit-triplestore

--- a/fcrepo-audit-triplestore/pom.xml
+++ b/fcrepo-audit-triplestore/pom.xml
@@ -40,10 +40,6 @@
         <artifactId>fcrepo-camel</artifactId>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-      </dependency>
-      <dependency>
         <groupId>org.fcrepo</groupId>
         <artifactId>fcrepo-audit</artifactId>
       </dependency>
@@ -67,6 +63,11 @@
       <dependency>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
         <scope>test</scope>
       </dependency>
   </dependencies>

--- a/fcrepo-indexing-triplestore/pom.xml
+++ b/fcrepo-indexing-triplestore/pom.xml
@@ -82,6 +82,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -93,6 +94,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <github.global.server>github</github.global.server>
 
     <!-- dependencies -->
-    <activemq.version>5.10.0</activemq.version>
+    <activemq.version>5.11.1</activemq.version>
     <camel.version>2.15.1</camel.version>
     <commons.lang3.version>3.3.2</commons.lang3.version>
     <jackson2.version>2.5.2</jackson2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <spring.version>4.1.5.RELEASE</spring.version>
     <!-- testing -->
     <awaitility.version>1.6.3</awaitility.version>
+    <commons.io.version>2.4</commons.io.version>
     <commons.logging.version>1.1.3</commons.logging.version>
     <grizzly.version>2.3.18</grizzly.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -154,11 +155,6 @@
         <version>${activemq.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.4</version>
-      </dependency>
-      <dependency>
         <groupId>org.fcrepo.camel</groupId>
         <artifactId>fcrepo-camel</artifactId>
         <version>${project.version}</version>
@@ -171,27 +167,12 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
           </exclusion>
-        </exclusions> 
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons.lang3.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.jena</groupId>
-        <artifactId>jena-fuseki</artifactId>
-        <version>${jena.fuseki.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.fcrepo</groupId>
@@ -269,7 +250,7 @@
         <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
-    
+
       <dependency>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-http-servlet</artifactId>
@@ -305,11 +286,42 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons.io.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-fuseki</artifactId>
+        <version>${jena.fuseki.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
   <build>
     <defaultGoal>install</defaultGoal>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
 
     <pluginManagement>
       <plugins>
@@ -389,6 +401,9 @@
               <goals>
                 <goal>reserve-network-port</goal>
               </goals>
+              <configuration>
+                <portNames/>
+              </configuration>
             </execution>
           </executions>
         </plugin>
@@ -528,6 +543,30 @@
 
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
+              <artifacts>
+                <artifact>
+                  <file>target/classes/features.xml</file>
+                  <type>xml</type>
+                  <classifier>features</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire.plugin.version}</version>
         <configuration>
@@ -575,6 +614,19 @@
             <id>default-report-integration</id>
             <goals>
               <goal>report-integration</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filter</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>resources</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/resources/features.xml
+++ b/src/main/resources/features.xml
@@ -1,0 +1,72 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0" name="fcrepo-camel-toolbox-${project.version}">
+  <repository>mvn:org.fcrepo.camel/fcrepo-camel/${project.version}/xml/features</repository>
+  <repository>mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features</repository>
+  <repository>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</repository>
+
+  <feature name="fcrepo-indexing-solr" version="${project.version}" resolver="(obr)" start-level="50">
+    <details>Installs the fcrepo solr indexer</details>
+    <bundle>mvn:org.fcrepo.camel/fcrepo-indexing-solr/${project.version}</bundle>
+
+    <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang3.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2.version}</bundle>
+
+    <feature version="${camel.version}">camel</feature>
+    <feature version="${camel.version}">camel-http4</feature>
+    <feature version="${camel.version}">camel-blueprint</feature>
+    <feature version="${camel.version}">camel-spring</feature>
+    <feature version="${activemq.version}">activemq-camel</feature>
+    <feature version="${project.version}">fcrepo-camel</feature>
+  </feature>
+
+  <feature name="fcrepo-indexing-triplestore" version="${project.version}" resolver="(obr)" start-level="50">
+    <details>Installs the fcrepo triplestore indexer</details>
+    <bundle>mvn:org.fcrepo.camel/fcrepo-indexing-triplestore/${project.version}</bundle>
+
+    <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons.lang3.version}</bundle>
+
+    <feature version="${camel.version}">camel</feature>
+    <feature version="${camel.version}">camel-http4</feature>
+    <feature version="${camel.version}">camel-blueprint</feature>
+    <feature version="${camel.version}">camel-spring</feature>
+    <feature version="${activemq.version}">activemq-camel</feature>
+    <feature version="${project.version}">fcrepo-camel</feature>
+  </feature>
+
+  <feature name="fcrepo-audit-triplestore" version="${project.version}" resolver="(obr)" start-level="50">
+    <details>Installs the fcrepo audit service with a triplestore backend</details>
+    <bundle>mvn:org.fcrepo.camel/fcrepo-audit-triplestore/${project.version}</bundle>
+
+    <!-- These should be moved into a self-contained feature, as a part of fcrepo-audit -->
+    <bundle dependency="true">mvn:org.fcrepo/fcrepo-audit/${project.version}</bundle>
+    <bundle dependency="true">mvn:org.fcrepo/fcrepo-metrics/${project.version}</bundle>
+    <bundle dependency="true">mvn:org.fcrepo/fcrepo-kernel/${project.version}</bundle>
+    <bundle dependency="true">mvn:org.fcrepo/fcrepo-kernel-impl/${project.version}</bundle>
+    <bundle dependency="true">mvn:org.fcrepo/fcrepo-mint/${project.version}</bundle>
+    <bundle dependency="true">mvn:javax.jcr/jcr/2.0</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2.external/javax.inject/2.3.0</bundle>
+    <bundle dependency="true">mvn:org.modeshape/modeshape-jcr-api/4.2.0.Final</bundle>
+    <bundle dependency="true">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+    <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-jvm/3.1.0</bundle>
+    <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-json/3.1.0</bundle>
+    <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-servlets/3.1.0</bundle>
+    <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-healthchecks/3.1.0</bundle>
+    <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-graphite/3.1.0</bundle>
+    <bundle dependency="true">mvn:io.dropwizard.metrics/metrics-core/3.1.0</bundle>
+    <bundle dependency="true">mvn:io.netty/netty/3.9.0.Final</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson2.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2.version}</bundle>
+    <!-- end of fcrepo-audit transitive dependencies -->
+
+    <feature version="${camel.version}">camel</feature>
+    <feature version="${camel.version}">camel-http4</feature>
+    <feature version="${camel.version}">camel-blueprint</feature>
+    <feature version="${camel.version}">camel-spring</feature>
+    <feature version="${activemq.version}">activemq-camel</feature>
+    <feature version="${project.version}">fcrepo-camel</feature>
+  </feature>
+
+</features>


### PR DESCRIPTION
Resolves https://jira.duraspace.org/browse/FCREPO-1479

I chose not to use the karaf plugin as it was overly eager in including transitive dependencies, but in certain cases not eager enough. Either way, it didn't work. For now, there are some hard-coded transitive dependencies listed for the fcrepo-audit module. This is necessary until the fcrepo-audit module is packaged as its own `feature`.