### PR TITLE
Using eventID instead of locally-generated UUID when building event URIs (FCREPO-1507)

### DIFF
--- a/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
+++ b/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
@@ -29,7 +29,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.UUID;
 
 import org.fcrepo.audit.AuditUtils;
 import org.fcrepo.camel.JmsHeaders;
@@ -66,8 +65,8 @@ public class AuditSparqlProcessor implements Processor {
     public void process(final Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
         final String eventURIBase = in.getHeader(AuditHeaders.EVENT_BASE_URI, String.class);
-        final String UUIDString = UUID.randomUUID().toString();
-        final UriRef eventURI = new UriRef(eventURIBase + "/" + UUIDString);
+        final String eventID = in.getHeader(JmsHeaders.EVENT_ID, String.class);
+        final UriRef eventURI = new UriRef(eventURIBase + "/" + eventID);
         final Set<Triple> triples = triplesForMessage(in, eventURI);
 
         // serialize triples

--- a/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/ProcessorTest.java
+++ b/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/ProcessorTest.java
@@ -59,6 +59,8 @@ public class ProcessorTest extends CamelTestSupport {
     private static final String eventDate = "2015-04-06T22:45:20Z";
     private static final String userID = "bypassAdmin";
     private static final String userAgent = "curl/7.37.1";
+    private static final String eventID = "ab/cd/ef/gh/abcdefgh12345678";
+    private static final String eventURI = eventBaseURI + "/" + eventID;
 
     @Test
     public void testNodeAdded() throws Exception {
@@ -71,20 +73,23 @@ public class ProcessorTest extends CamelTestSupport {
         final String eventProps = REPOSITORY + "lastModified," + REPOSITORY + "primaryType," +
                 REPOSITORY + "lastModifiedBy," + REPOSITORY + "created," + REPOSITORY + "mixinTypes," +
                 REPOSITORY + "createdBy," + REPOSITORY + "uuid";
-        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, eventProps));
+        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, eventProps, eventID));
 
         assertMockEndpointsSatisfied();
         final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
         assertTrue("Event type not found!",
-            body.contains("<" + PREMIS + "hasEventType> <" + EVENT_TYPE + "cre>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventType> <" + EVENT_TYPE + "cre>"));
         assertTrue("Object link not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
         assertTrue("Event date not found!",
-            body.contains("<" + PREMIS + "hasEventDateTime> \"" + eventDate + "\"^^<" + XSD + "dateTime>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventDateTime> \"" + eventDate + "\"^^<"
+                    + XSD + "dateTime>"));
         assertTrue("Event user not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedAgent> \"" + userID + "\"^^<" + XSD + "string>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedAgent> \"" + userID + "\"^^<"
+                    + XSD + "string>"));
         assertTrue("Event agent not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedAgent> \"" + userAgent + "\"^^<" + XSD + "string>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedAgent> \"" + userAgent + "\"^^<"
+                    + XSD + "string>"));
     }
 
     @Test
@@ -95,14 +100,14 @@ public class ProcessorTest extends CamelTestSupport {
         resultEndpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
 
         final String eventTypes = REPOSITORY + "NODE_REMOVED";
-        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, null));
+        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, null, eventID));
 
         assertMockEndpointsSatisfied();
         final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
         assertTrue("Event type not found!",
-            body.contains("<" + PREMIS + "hasEventType> <" + EVENT_TYPE + "del>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventType> <" + EVENT_TYPE + "del>"));
         assertTrue("Object link not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
     }
 
     @Test
@@ -114,14 +119,14 @@ public class ProcessorTest extends CamelTestSupport {
 
         final String eventTypes = REPOSITORY + "PROPERTY_CHANGED," + REPOSITORY + "PROPERTY_ADDED";
         final String eventProps = REPOSITORY + "lastModified,http://purl.org/dc/elements/1.1/title";
-        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, eventProps));
+        template.sendBodyAndHeaders("", createEvent(nodeID, eventTypes, eventProps, eventID));
 
         assertMockEndpointsSatisfied();
         final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
         assertTrue("Event type not found!",
-            body.contains("<" + PREMIS + "hasEventType> <" + AUDIT + "metadataModification>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventType> <" + AUDIT + "metadataModification>"));
         assertTrue("Object link not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedObject> <" + baseURL + nodeID + ">"));
     }
 
     @Test
@@ -136,14 +141,14 @@ public class ProcessorTest extends CamelTestSupport {
                 REPOSITORY + "lastModifiedBy," + REPOSITORY + "created," + REPOSITORY + "mixinTypes," +
                 REPOSITORY + "createdBy," + REPOSITORY + "uuid" + REPOSITORY + "hasContent," +
                 PREMIS + "hasSize," + PREMIS + "hasOriginalName," + REPOSITORY + "digest";
-        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps));
+        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps, eventID));
 
         assertMockEndpointsSatisfied();
         final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
         assertTrue("Event type not found!",
-            body.contains("<" + PREMIS + "hasEventType> <" + EVENT_TYPE + "ing>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventType> <" + EVENT_TYPE + "ing>"));
         assertTrue("Object link not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
     }
 
     @Test
@@ -156,14 +161,14 @@ public class ProcessorTest extends CamelTestSupport {
         final String eventTypes = REPOSITORY + "PROPERTY_CHANGED";
         final String eventProps = REPOSITORY + "lastModified," + REPOSITORY + "hasContent," +
                 PREMIS + "hasSize," + PREMIS + "hasOriginalName," + REPOSITORY + "digest";
-        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps));
+        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps, eventID));
 
         assertMockEndpointsSatisfied();
         final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
         assertTrue("Event type not found!",
-            body.contains("<" + PREMIS + "hasEventType> <" + AUDIT + "contentModification>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventType> <" + AUDIT + "contentModification>"));
         assertTrue("Object link not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
     }
 
     @Test
@@ -175,18 +180,18 @@ public class ProcessorTest extends CamelTestSupport {
 
         final String eventTypes = REPOSITORY + "NODE_REMOVED";
         final String eventProps = REPOSITORY + "hasContent";
-        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps));
+        template.sendBodyAndHeaders("", createEvent(fileID, eventTypes, eventProps, eventID));
 
         assertMockEndpointsSatisfied();
         final String body = (String)resultEndpoint.assertExchangeReceived(0).getIn().getBody();
         assertTrue("Event type not found!",
-            body.contains("<" + PREMIS + "hasEventType> <" + AUDIT + "contentRemoval>"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventType> <" + AUDIT + "contentRemoval>"));
         assertTrue("Object link not found!",
-            body.contains("<" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
+            body.contains("<" + eventURI + "> <" + PREMIS + "hasEventRelatedObject> <" + baseURL + fileID + ">"));
     }
 
     private static Map<String,Object> createEvent(final String identifier, final String eventTypes,
-            final String eventProperties) {
+            final String eventProperties, final String eventID) {
 
         final Map<String, Object> headers = new HashMap<>();
         headers.put(JmsHeaders.BASE_URL, baseURL);
@@ -196,6 +201,7 @@ public class ProcessorTest extends CamelTestSupport {
         headers.put(JmsHeaders.USER_AGENT, userAgent);
         headers.put(JmsHeaders.EVENT_TYPE, eventTypes);
         headers.put(JmsHeaders.PROPERTIES, eventProperties);
+        headers.put(JmsHeaders.EVENT_ID, eventID);
         return headers;
     }
 

--- a/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/integration/AuditSparqlIT.java
+++ b/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/integration/AuditSparqlIT.java
@@ -63,6 +63,12 @@ public class AuditSparqlIT extends CamelTestSupport {
 
     private static final String USER_AGENT = "curl/7.37.1";
 
+    private static final String EVENT_BASE_URI = "http://example.com/event";
+
+    private static final String EVENT_ID = "ab/cd/ef/gh/abcdefgh12345678";
+
+    private static final String EVENT_URI = EVENT_BASE_URI + "/" + EVENT_ID;
+
     @EndpointInject(uri = "mock:sparql.update")
     protected MockEndpoint sparqlUpdateEndpoint;
 
@@ -110,6 +116,7 @@ public class AuditSparqlIT extends CamelTestSupport {
         headers.put(JmsHeaders.TIMESTAMP, 1428676236521L);
         headers.put(JmsHeaders.USER, USER);
         headers.put(JmsHeaders.USER_AGENT, USER_AGENT);
+        headers.put(JmsHeaders.EVENT_ID, EVENT_ID);
 
         return headers;
     }
@@ -128,7 +135,7 @@ public class AuditSparqlIT extends CamelTestSupport {
         template.sendBodyAndHeaders(null, getEventHeaders());
 
         template.sendBodyAndHeader("direct:query", null, Exchange.HTTP_QUERY,
-                "query=SELECT ?o WHERE { ?s <" + PREMIS + "hasEventType> ?o }");
+                "query=SELECT ?o WHERE { <" + EVENT_URI + "> <" + PREMIS + "hasEventType> ?o }");
 
         sparqlQueryEndpoint.assertIsSatisfied();
         sparqlUpdateEndpoint.assertIsSatisfied();
@@ -149,7 +156,7 @@ public class AuditSparqlIT extends CamelTestSupport {
         template.sendBodyAndHeaders(null, getEventHeaders());
 
         template.sendBodyAndHeader("direct:query", null, Exchange.HTTP_QUERY,
-                "query=SELECT ?o WHERE { ?s <" + PREMIS + "hasEventRelatedObject> ?o }");
+                "query=SELECT ?o WHERE { <" + EVENT_URI + "> <" + PREMIS + "hasEventRelatedObject> ?o }");
 
         sparqlQueryEndpoint.assertIsSatisfied();
         sparqlUpdateEndpoint.assertIsSatisfied();
@@ -170,7 +177,7 @@ public class AuditSparqlIT extends CamelTestSupport {
         template.sendBodyAndHeaders(null, getEventHeaders());
 
         template.sendBodyAndHeader("direct:query", null, Exchange.HTTP_QUERY,
-                "query=SELECT ?o WHERE { ?s <" + PREMIS + "hasEventDateTime> ?o }");
+                "query=SELECT ?o WHERE { <" + EVENT_URI + "> <" + PREMIS + "hasEventDateTime> ?o }");
 
         sparqlQueryEndpoint.assertIsSatisfied();
         sparqlUpdateEndpoint.assertIsSatisfied();
@@ -192,7 +199,7 @@ public class AuditSparqlIT extends CamelTestSupport {
         template.sendBodyAndHeaders(null, getEventHeaders());
 
         template.sendBodyAndHeader("direct:query", null, Exchange.HTTP_QUERY,
-                "query=SELECT ?o WHERE { ?s <" + PREMIS + "hasEventRelatedAgent> ?o }");
+                "query=SELECT ?o WHERE { <" + EVENT_URI + "> <" + PREMIS + "hasEventRelatedAgent> ?o }");
 
         sparqlQueryEndpoint.assertIsSatisfied();
         sparqlUpdateEndpoint.assertIsSatisfied();
@@ -210,7 +217,7 @@ public class AuditSparqlIT extends CamelTestSupport {
         template.sendBodyAndHeaders(null, getEventHeaders());
 
         template.sendBodyAndHeader("direct:query", null, Exchange.HTTP_QUERY,
-                "query=SELECT ?o WHERE { ?s ?p ?o }");
+                "query=SELECT ?o WHERE { <" + EVENT_URI + "> ?p ?o }");
 
         sparqlQueryEndpoint.assertIsSatisfied();
         sparqlUpdateEndpoint.assertIsSatisfied();
@@ -233,7 +240,7 @@ public class AuditSparqlIT extends CamelTestSupport {
         template.sendBodyAndHeaders(null, getEventHeaders());
 
         template.sendBodyAndHeader("direct:query", null, Exchange.HTTP_QUERY,
-                "query=SELECT ?o WHERE { ?s <" + RDF + "type> ?o }");
+                "query=SELECT ?o WHERE { <" + EVENT_URI + "> <" + RDF + "type> ?o }");
 
         sparqlQueryEndpoint.assertIsSatisfied();
         sparqlUpdateEndpoint.assertIsSatisfied();
@@ -261,7 +268,7 @@ public class AuditSparqlIT extends CamelTestSupport {
                 final String fuseki_url = "localhost:" + Integer.toString(FUSEKI_PORT);
 
                 from("direct:start")
-                    .setHeader(AuditHeaders.EVENT_BASE_URI, constant("http://example.com/event"))
+                    .setHeader(AuditHeaders.EVENT_BASE_URI, constant(EVENT_BASE_URI))
                     .process(new AuditSparqlProcessor())
                     .to("http4:" + fuseki_url + "/test/update")
                     .to("mock:sparql.update");

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
       <dependency>
         <groupId>org.fcrepo.camel</groupId>
         <artifactId>fcrepo-camel</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.1-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Fourth step in https://jira.duraspace.org/browse/FCREPO-1507