### PR TITLE
Add stopWait configuration for jetty-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,7 @@
               </systemProperty>
             </systemProperties>
             <scanIntervalSeconds>10</scanIntervalSeconds>
+            <stopWait>5</stopWait>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
Was getting a failed build while building with tests turned off. The exception seems to be a known issue with the jetty-maven-plugin (https://bugs.eclipse.org/bugs/show_bug.cgi?id=412637).

I've added the stopWait configuration mentioned in the ticket to this project's pom.xml and the builds are no longer failing for me.