### PR TITLE
Remove duplicate logback from jetty-maven-plugin's classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,11 +497,6 @@
           </configuration>
           <dependencies>
             <dependency>
-              <groupId>ch.qos.logback</groupId>
-              <artifactId>logback-classic</artifactId>
-              <version>${logback.version}</version>
-            </dependency>
-            <dependency>
               <groupId>org.slf4j</groupId>
               <artifactId>jcl-over-slf4j</artifactId>
               <version>${slf4j.version}</version>


### PR DESCRIPTION
When running a build, I get the following warning in the Maven output:

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/tmp/jetty-0.0.0.0-0-fcrepo.war-_fcrepo-any-8021681995411204556.dir/webapp/WEB-INF/lib/logback-classic-1.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/kevin/.m2/repository/ch/qos/logback/logback-classic/1.1.2/logback-classic-1.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
```

This pull request removes the logback dependency from the jetty-maven-plugin configuration since there is already a version of it on the app's classpath.